### PR TITLE
fix: jogabilidade mais justa, input no mobile e atualizacao do PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,47 @@
   </a>
   <br />
   <i>Nostálgico jogo da cobrinha desenvolvido em JavaScript.</i>
+  <br />
+  <br />
+  <a href="https://lucasrmagalhaes.github.io/snake-js/"><strong>▶ Jogar online</strong></a>
 </p>
+
+<hr />
+
+<details>
+
+  <summary><strong>Como jogar</strong></summary>
+
+  <br />
+
+  <ul>
+    <li><strong>Setas</strong> ou <strong>WASD</strong> — mover a cobrinha;</li>
+    <li><strong>Espaço</strong> ou <strong>Enter</strong> — começar / reiniciar;</li>
+    <li><strong>Espaço</strong> ou <strong>P</strong> — pausar e retomar;</li>
+    <li><strong>L</strong> — abrir/fechar o ranking global; e</li>
+    <li><strong>Swipe</strong> na tela — controles em dispositivos móveis.</li>
+  </ul>
+
+</details>
+
+<hr />
+
+<details>
+
+  <summary><strong>Rodando localmente</strong></summary>
+
+  <br />
+
+  <p>O jogo usa módulos ES, então precisa ser servido via HTTP — abrir o <code>index.html</code> direto do disco (<code>file://</code>) não funciona:</p>
+
+<pre><code>git clone https://github.com/lucasrmagalhaes/snake-js.git
+cd snake-js
+npx serve .
+# ou: python -m http.server 8000</code></pre>
+
+  <p>Depois é só abrir a URL indicada no terminal (ex.: <code>http://localhost:3000</code>).</p>
+
+</details>
 
 <hr />
 
@@ -23,8 +63,8 @@
     <li>Alterado a cor de background;</li>
     <li>Adicionado espaçamento entre os quadrados da cobrinha;</li>
     <li>Fix pelo <a href="https://github.com/roanrobersson">@roanrobersson</a> - Cobrinha deixou de sumir durante teletransporte + keydown; e</li>
-    <li>Feat pelo <a href="https://github.com/Jorgewlf88">@Jorgewlf88</a> - Suporte para dispositivos móveis.
-    <li>Feat pelo <a href="https://github.com/MaurerKrisztian">@MaurerKrisztian</a> - Adicionado configuração de velocidade e pontuação.
+    <li>Feat pelo <a href="https://github.com/Jorgewlf88">@Jorgewlf88</a> - Suporte para dispositivos móveis.</li>
+    <li>Feat pelo <a href="https://github.com/MaurerKrisztian">@MaurerKrisztian</a> - Adicionado configuração de velocidade e pontuação.</li>
     <li>Score real, high score persistido em <code>localStorage</code> e tela de Game Over no canvas (sem <code>alert</code>).</li>
     <li>Tela inicial com instruções, pausa (Space/P) e suporte a WASD além das setas.</li>
     <li>Visual repaginado: cabeça com olhos direcionais, segmentos arredondados, grid sutil, comida com gradiente e pulsação.</li>
@@ -36,6 +76,7 @@
     <li>6 personagens de cobra selecionáveis: <strong>Verdão</strong>, <strong>Coral</strong>, <strong>Jararaca</strong>, <strong>Píton</strong>, <strong>Naja</strong> e <strong>Brasa</strong>.</li>
     <li>Canvas widescreen 25×13 (proporção ~16:9), responsivo em mobile e modo fullscreen.</li>
     <li>Favicon SVG temático.</li>
+    <li>Colisão justa com a cauda, comida nunca nasce sob a cabeça, teclas do jogo não rolam mais a página, swipe corrigido no mobile e cache do PWA com atualização automática.</li>
   </ol>
 
 </details>
@@ -49,8 +90,8 @@
   <br />
   
   <p align="left">
-    Plataforma: <a href="https://web.digitalinnovation.one/home">Digital Innovation One</a> <br /> 
-    Desafio: <a href="https://web.digitalinnovation.one/course/desafio-pratico-recriando-o-jogo-da-cobrinha-com-javascript/learning/66d83831-bae1-45f7-b2ea-af7d64d5d4f5?back=/track/desenvolvedor-front-end-reactjs&bootcamp_id=abf8f19f-691b-4dac-a14a-11ddcf3a14cd">Recriando o Jogo da Cobrinha com JavaScript</a>
+    Plataforma: <a href="https://www.dio.me">Digital Innovation One</a> <br /> 
+    Desafio: Recriando o Jogo da Cobrinha com JavaScript
   </p>
   
 </details>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie-edge">
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="manifest" href="manifest.json">
     <meta name="theme-color" content="#0d0d10">

--- a/js/game.js
+++ b/js/game.js
@@ -88,29 +88,36 @@ export function tick() {
         else if (snakeY >= boardH) snakeY = 0;
     }
 
+    const now = performance.now();
+    if (state.specialFood && now > state.specialFood.expires) state.specialFood = null;
+
+    const ateNormal = state.food && snakeX === state.food.x && snakeY === state.food.y;
+    const ateSpecial = state.specialFood && snakeX === state.specialFood.x && snakeY === state.specialFood.y;
+    const willGrow = ateNormal || ateSpecial;
+
+    // Quando a cobra nao cresce, a cauda desocupa a celula neste mesmo tick;
+    // mover a cabeca para a celula da cauda nao pode contar como colisao.
+    const lastIndex = state.snake.length - 1;
     for (let i = 0; i < state.snake.length; i++) {
+        if (!willGrow && i === lastIndex) continue;
         if (snakeX === state.snake[i].x && snakeY === state.snake[i].y) {
             gameOver();
             return;
         }
     }
 
-    const now = performance.now();
-    if (state.specialFood && now > state.specialFood.expires) state.specialFood = null;
+    const newHead = { x: snakeX, y: snakeY };
 
-    const ateNormal = snakeX === state.food.x && snakeY === state.food.y;
-    const ateSpecial = state.specialFood && snakeX === state.specialFood.x && snakeY === state.specialFood.y;
-
-    if (!ateNormal && !ateSpecial) {
+    if (!willGrow) {
         state.snake.pop();
     } else {
         if (ateNormal) {
             state.score++;
             state.eatEffect = { x: state.food.x, y: state.food.y, start: now, color: "255, 71, 87" };
-            state.food = spawnFreeCell(state.specialFood ? [state.specialFood] : []);
+            state.food = spawnFreeCell(state.specialFood ? [state.specialFood, newHead] : [newHead]);
             playEat();
             if (!state.specialFood && Math.random() < SPECIAL_CHANCE) {
-                const pos = spawnFreeCell([state.food]);
+                const pos = spawnFreeCell(state.food ? [state.food, newHead] : [newHead]);
                 if (pos) state.specialFood = { x: pos.x, y: pos.y, expires: now + SPECIAL_TTL };
             }
         }
@@ -123,5 +130,5 @@ export function tick() {
         setSpeed(effectiveInterval());
     }
 
-    state.snake.unshift({ x: snakeX, y: snakeY });
+    state.snake.unshift(newHead);
 }

--- a/js/input.js
+++ b/js/input.js
@@ -7,7 +7,11 @@ export function setDirection(dir) {
     if (dir !== opposite[state.direction]) state.nextDirection = dir;
 }
 
+// Espaco e setas rolariam a pagina durante o jogo.
+const SCROLL_KEYS = [32, 37, 38, 39, 40];
+
 function handleKey(event) {
+    if (SCROLL_KEYS.includes(event.keyCode)) event.preventDefault();
     if (state.showingLeaderboard) {
         if (event.keyCode === 27 || event.keyCode === 76) closeLeaderboard();
         return;
@@ -59,5 +63,7 @@ function moveTouch(e) {
 export function bindInputs() {
     document.addEventListener("keydown", handleKey);
     document.addEventListener("touchstart", startTouch, false);
-    document.addEventListener("touchmove", moveTouch, false);
+    // passive: false — listeners de touchmove em document sao passivos por
+    // padrao no Chrome, o que anularia o preventDefault() do swipe.
+    document.addEventListener("touchmove", moveTouch, { passive: false });
 }

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = "snake-v2";
+const CACHE = "snake-v3";
 const ASSETS = [
     "./",
     "./index.html",
@@ -34,12 +34,19 @@ self.addEventListener("fetch", e => {
     if (url.origin !== location.origin) return;
     if (e.request.method !== "GET") return;
 
+    // Stale-while-revalidate: responde rapido pelo cache, mas sempre busca a
+    // versao nova em segundo plano — assim novos deploys chegam aos usuarios
+    // sem depender de trocar o nome do cache.
     e.respondWith(
-        caches.match(e.request).then(cached => cached || fetch(e.request).then(resp => {
-            if (!resp || resp.status !== 200 || resp.type !== "basic") return resp;
-            const clone = resp.clone();
-            caches.open(CACHE).then(c => c.put(e.request, clone));
-            return resp;
-        }))
+        caches.match(e.request).then(cached => {
+            const fetchAndUpdate = fetch(e.request).then(resp => {
+                if (resp && resp.status === 200 && resp.type === "basic") {
+                    const clone = resp.clone();
+                    caches.open(CACHE).then(c => c.put(e.request, clone));
+                }
+                return resp;
+            }).catch(() => cached);
+            return cached || fetchAndUpdate;
+        })
     );
 });


### PR DESCRIPTION
## Melhorias aplicadas

### Jogabilidade (`js/game.js`)
- **Colisão justa com a cauda**: mover a cabeça para a célula que a cauda desocupa no mesmo tick não é mais game over (comportamento clássico do Snake). Colisões reais com o corpo continuam matando — os dois cenários foram testados no navegador.
- **Comida nunca nasce sob a nova cabeça**: a célula da nova cabeça agora é excluída do sorteio da comida normal e da especial (antes a comida podia renascer exatamente onde a cabeça ia entrar, ficando escondida sob a cobra).
- Guarda para `state.food` nula quando o tabuleiro está cheio (evitava crash teórico no fim de jogo perfeito).

### Input (`js/input.js`)
- `preventDefault()` em espaço e setas: em janelas menores, a página rolava junto com os comandos do jogo.
- `touchmove` registrado com `{ passive: false }`: no Chrome, listeners de `touchmove` em `document` são passivos por padrão, então o `preventDefault()` do swipe era ignorado e a página rolava durante o gesto no mobile.

### PWA (`sw.js`)
- Estratégia do fetch muda de cache-first puro para **stale-while-revalidate**: responde rápido pelo cache, mas busca a versão nova em segundo plano. Antes, sem trocar o nome do cache a cada deploy, usuários instalados nunca recebiam atualizações.
- Bump do cache para `snake-v3` para renovar os assets na próxima visita.

### Docs e HTML (`README.md`, `index.html`)
- Novas seções **Como jogar** (todos os controles, teclado e swipe) e **Rodando localmente** (módulos ES exigem servidor HTTP; `file://` não funciona), além de link "Jogar online" no topo.
- Links da DIO corrigidos: `web.digitalinnovation.one` hoje redireciona para uma página 404; plataforma agora aponta para `www.dio.me` e o desafio virou texto.
- Fechadas tags `</li>` faltantes na lista de updates.
- Removida a meta `X-UA-Compatible` obsoleta (que ainda por cima tinha o valor inválido `ie-edge` em vez de `IE=edge`).

## Verificação
- `node --check` em todos os módulos JS e no `sw.js`.
- Jogo servido localmente e testado no navegador: partida inicia, teclas prevenidas corretamente (P/Enter não são bloqueados), e os dois cenários de colisão (cauda que sai vs. corpo) validados chamando `tick()` direto nos módulos.

## Achados para revisar (não corrigidos)
- **Firestore aberto para escrita via REST**: a API key do Firebase em `js/config.js` é pública por design em apps web, mas o endpoint de `scores` aceita POST de qualquer origem — qualquer pessoa consegue inserir score arbitrário no ranking (spam/cheating). Vale restringir com Security Rules (ex.: validar tipos/limites) e considerar App Check.
- `event.keyCode` é deprecated; migrar para `event.key` em `js/input.js` numa próxima leva.
- Limitação conhecida de input: dois comandos de direção no mesmo tick não são enfileirados (ex.: baixo+esquerda muito rápido); um buffer de direções resolveria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)