### PR TITLE
Security Rules do Firestore para o ranking + migracao de keyCode para key

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,36 @@ npx serve .
 <hr />
 
 <details>
+
+  <summary><strong>Ranking e segurança (Firestore)</strong></summary>
+
+  <br />
+
+  <p>O ranking global grava os scores em um Firestore via REST (<code>js/leaderboard.js</code>), direto do navegador. Isso significa que <strong>sem Security Rules o banco aceita escrita de qualquer origem</strong>: qualquer pessoa com a URL do projeto consegue inserir um score arbitrário (ex.: <code>999999</code>), editar ou apagar documentos — a API key do Firebase não é segredo e não protege nada sozinha.</p>
+
+  <p>O arquivo <a href="firestore.rules"><code>firestore.rules</code></a> na raiz do repositório mitiga isso validando o formato exato que o jogo envia:</p>
+
+  <ul>
+    <li><code>name</code> — string de 1 a 20 caracteres;</li>
+    <li><code>score</code> — inteiro entre 0 e 2000 (teto folgado sobre o máximo teórico de gameplay, ~1625 no tabuleiro 25×13);</li>
+    <li><code>ts</code> — timestamp;</li>
+    <li>nenhum campo extra, e <strong>sem update/delete público</strong> — só criação e leitura.</li>
+  </ul>
+
+  <p><strong>⚠️ As rules não se aplicam sozinhas</strong> — precisam de deploy manual no projeto Firebase (passo do dono do projeto):</p>
+
+  <ul>
+    <li><strong>Console:</strong> <a href="https://console.firebase.google.com/">Firebase Console</a> → Firestore Database → aba <em>Regras</em> → colar o conteúdo de <code>firestore.rules</code> → <em>Publicar</em>; ou</li>
+    <li><strong>CLI:</strong> <code>firebase deploy --only firestore:rules</code> (com o <a href="https://firebase.google.com/docs/cli">Firebase CLI</a> autenticado e o arquivo referenciado no <code>firebase.json</code>).</li>
+  </ul>
+
+  <p>As rules validam <em>formato</em>, não <em>legitimidade</em>: um script ainda pode enviar um score falso desde que passe na validação. Para reforçar, ative o <a href="https://firebase.google.com/docs/app-check">Firebase App Check</a>, que exige um atestado (ex.: reCAPTCHA) de que a requisição vem do app web real antes de aceitar a escrita.</p>
+
+</details>
+
+<hr />
+
+<details>
   
   <summary><strong>Updates</strong></summary>
   

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,46 @@
+rules_version = '2';
+
+// Regras de seguranca do ranking (colecao "scores").
+//
+// O cliente (js/leaderboard.js) grava documentos exatamente neste formato:
+//   name  -> string  (nome do jogador, trim + slice(0, 20))
+//   score -> int     (integerValue enviado via REST)
+//   ts    -> timestamp (timestampValue com new Date().toISOString())
+//
+// Teto do score: o tabuleiro tem 25x13 = 325 celulas (js/config.js). Cada
+// comida cresce a cobra em 1 celula; a normal vale +1 e a especial vale +5
+// (SPECIAL_SCORE). Mesmo no cenario impossivel de so comer especiais, o
+// maximo teorico seria ~325 * 5 = 1625. O limite de 2000 da folga para
+// ajustes futuros de gameplay sem aceitar valores absurdos.
+//
+// Deploy: firebase deploy --only firestore:rules (ou pelo console do
+// Firebase). Veja a secao "Ranking e seguranca" no README.
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /scores/{scoreId} {
+      // Leitura publica: o jogo consulta o top 20 via runQuery.
+      allow read: if true;
+
+      // Escrita: apenas criacao de documentos no formato exato acima.
+      allow create: if
+        request.resource.data.keys().hasOnly(['name', 'score', 'ts']) &&
+        request.resource.data.keys().hasAll(['name', 'score', 'ts']) &&
+        request.resource.data.name is string &&
+        request.resource.data.name.size() >= 1 &&
+        request.resource.data.name.size() <= 20 &&
+        request.resource.data.score is int &&
+        request.resource.data.score >= 0 &&
+        request.resource.data.score <= 2000 &&
+        request.resource.data.ts is timestamp;
+
+      // Ninguem edita nem apaga scores pelo cliente.
+      allow update, delete: if false;
+    }
+
+    // Qualquer outra colecao permanece inacessivel.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/js/input.js
+++ b/js/input.js
@@ -8,34 +8,37 @@ export function setDirection(dir) {
 }
 
 // Espaco e setas rolariam a pagina durante o jogo.
-const SCROLL_KEYS = [32, 37, 38, 39, 40];
+const SCROLL_KEYS = [" ", "ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown"];
 
 function handleKey(event) {
-    if (SCROLL_KEYS.includes(event.keyCode)) event.preventDefault();
+    // Letras chegam minusculas para casar com/sem Shift ou Caps Lock,
+    // como o antigo event.keyCode (deprecated) fazia.
+    const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+    if (SCROLL_KEYS.includes(key)) event.preventDefault();
     if (state.showingLeaderboard) {
-        if (event.keyCode === 27 || event.keyCode === 76) closeLeaderboard();
+        if (key === "Escape" || key === "l") closeLeaderboard();
         return;
     }
-    if (event.keyCode === 76) {
+    if (key === "l") {
         openLeaderboard();
         return;
     }
     if (state.isReady) {
-        if (event.keyCode === 13 || event.keyCode === 32) state.isReady = false;
+        if (key === "Enter" || key === " ") state.isReady = false;
         return;
     }
     if (state.isGameOver) {
-        if (event.keyCode === 13 || event.keyCode === 32) resetGame();
+        if (key === "Enter" || key === " ") resetGame();
         return;
     }
-    if (event.keyCode === 32 || event.keyCode === 80) {
+    if (key === " " || key === "p") {
         state.isPaused = !state.isPaused;
         return;
     }
-    if (event.keyCode === 37 || event.keyCode === 65) setDirection("left");
-    if (event.keyCode === 38 || event.keyCode === 87) setDirection("up");
-    if (event.keyCode === 39 || event.keyCode === 68) setDirection("right");
-    if (event.keyCode === 40 || event.keyCode === 83) setDirection("down");
+    if (key === "ArrowLeft" || key === "a") setDirection("left");
+    if (key === "ArrowUp" || key === "w") setDirection("up");
+    if (key === "ArrowRight" || key === "d") setDirection("right");
+    if (key === "ArrowDown" || key === "s") setDirection("down");
 }
 
 function startTouch(e) {


### PR DESCRIPTION
## Contexto

O ranking grava scores num Firestore via REST (`js/leaderboard.js`) e o banco hoje aceita escrita de **qualquer origem**: qualquer pessoa pode inserir um score arbitrário, editar ou apagar documentos — a API key do Firebase é pública por natureza e não protege nada sozinha.

## O que muda

### 1. `firestore.rules` (novo, na raiz)
Security Rules que validam o formato exato que o jogo envia:
- `name`: string de 1 a 20 caracteres (o cliente já faz `trim().slice(0, 20)`);
- `score`: inteiro entre 0 e 2000 — teto folgado sobre o máximo teórico de gameplay (~1625 no tabuleiro 25×13, com comida normal +1 e especial +5);
- `ts`: timestamp;
- nenhum campo extra (`hasOnly` + `hasAll`);
- **sem update/delete público** — só `create` e leitura;
- qualquer outra coleção permanece bloqueada.

### 2. README — seção "Ranking e segurança (Firestore)"
Explica o risco atual, documenta o deploy das rules (console do Firebase ou `firebase deploy --only firestore:rules`) e cita o **Firebase App Check** como reforço contra scores forjados que passem na validação de formato.

### 3. `js/input.js` — `event.keyCode` → `event.key`
`keyCode` é deprecated. Mapeamentos preservados: setas/WASD, Espaço, Enter, Escape, P e L, com `toLowerCase` nas letras para funcionar com Shift/Caps Lock como antes.

## ⚠️ Passo manual do dono (as rules NÃO se aplicam sozinhas)

Não há como aplicar as rules a partir deste PR — exige acesso ao projeto Firebase (`snake-a82fa`). Após o merge:
- **Console:** Firebase Console → Firestore Database → aba *Regras* → colar o conteúdo de `firestore.rules` → *Publicar*; **ou**
- **CLI:** `firebase deploy --only firestore:rules`.

## Verificação
- `node --check` limpo em todos os `js/*.js` e `sw.js`;
- smoke test local (servidor estático + navegador): Enter inicia o jogo, setas e WASD (inclusive maiúsculas) mudam a direção, Espaço/P pausam e retomam, L abre o ranking (o `runQuery` ao Firestore retornou 10 entradas reais) e Esc fecha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)